### PR TITLE
Fix dev container reopen error and add simple devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,7 +74,7 @@ RUN git config --system --add safe.directory '*'
 USER devuser
 WORKDIR /home/devuser
 
-RUN pip install --user --no-cache-dir \
+RUN pip install --user --no-cache-dir --break-system-packages \
     ansible-core \
     ansible-runner \
     molecule \
@@ -146,7 +146,7 @@ RUN pacman -S --noconfirm \
 USER devuser
 
 # Install additional development Python packages
-RUN pip install --user --no-cache-dir \
+RUN pip install --user --no-cache-dir --break-system-packages \
     black \
     flake8 \
     mypy \

--- a/.devcontainer/devcontainer-simple.json
+++ b/.devcontainer/devcontainer-simple.json
@@ -1,0 +1,24 @@
+{
+    "name": "Arch Linux Desktop Automation (Simple)",
+    "image": "archlinux:latest",
+    "workspaceFolder": "/workspace",
+    "shutdownAction": "stopContainer",
+    "remoteUser": "root",
+    
+    "postCreateCommand": "pacman -Sy --noconfirm && pacman -S --noconfirm git python python-pip ansible base-devel && mkdir -p /workspace",
+    
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.vscode-yaml",
+                "redhat.ansible",
+                "ms-python.python",
+                "timonwong.shellcheck"
+            ]
+        }
+    },
+    
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ]
+}

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -48,7 +48,7 @@ main() {
     # Install Python requirements
     if [[ -f "requirements.txt" ]]; then
         log_info "Installing Python requirements..."
-        pip install --user -r requirements.txt || {
+        pip install --user --break-system-packages -r requirements.txt || {
             log_warn "Failed to install some Python requirements"
         }
     fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Git
+.git
+.gitignore
+
+# Development
+.dev
+.devcontainer/.devcontainer
+logs/
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+.venv/
+.cache/
+
+# Node.js
+node_modules/
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Temporary files
+*.tmp
+*.temp
+tmp/
+temp/
+
+# Build artifacts
+build/
+dist/
+target/
+
+# Docker
+Dockerfile*
+docker-compose*
+
+# Testing
+.coverage
+.pytest_cache/
+.tox/
+
+# Documentation builds  
+site/
+_build/


### PR DESCRIPTION
## Summary
- Fixes dev container reopen error by adding `--break-system-packages` flag to pip installs
- Adds a new simple devcontainer configuration for Arch Linux Desktop Automation
- Adds a comprehensive `.dockerignore` file to improve Docker build context

## Changes

### Dockerfile
- Updated pip install commands to include `--break-system-packages` flag to avoid package conflicts

### Devcontainer Configuration
- Added `.devcontainer/devcontainer-simple.json` with a minimal Arch Linux setup:
  - Uses `archlinux:latest` image
  - Installs essential packages like git, python, pip, ansible, base-devel
  - Sets up VSCode extensions for YAML, Ansible, Python, and ShellCheck
  - Mounts Docker socket for container management

### Scripts
- Updated `.devcontainer/scripts/post-create.sh` to use `--break-system-packages` flag when installing Python requirements

### Dockerignore
- Added `.dockerignore` file to exclude unnecessary files and directories from Docker build context, including:
  - Git files, logs, Python cache, node_modules, OS files, IDE configs, temporary files, build artifacts, Docker files, and testing caches

## Test plan
- [x] Build and reopen dev container without pip package errors
- [x] Verify simple devcontainer config builds and sets up environment correctly
- [x] Confirm `.dockerignore` excludes specified files during Docker build
- [x] Run post-create script and ensure Python requirements install successfully

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/caed893d-def3-41b8-9804-999096742fc2