### PR TITLE
Fix git clone command syntax in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -119,10 +119,10 @@ RUN pacman -S --noconfirm \
 # Install additional tools from AUR (using a temporary user)
 RUN useradd -m -G wheel temp_user && \
     echo "temp_user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    su - temp_user -c "
+    su - temp_user -c "\
         git clone https://aur.archlinux.org/yay.git /tmp/yay && \
         cd /tmp/yay && \
-        makepkg -si --noconfirm
+        makepkg -si --noconfirm\
     " && \
     su - temp_user -c "
         yay -S --noconfirm \


### PR DESCRIPTION
## Summary
- Corrects the syntax of the git clone and makepkg commands in Dockerfile.dev
- Ensures proper command continuation within the temporary user shell

## Changes

### Dockerfile.dev
- Updated the `su - temp_user -c` command to use backslash for line continuation instead of newline
- Fixed the `makepkg -si --noconfirm` command to be properly chained within the shell command

## Test plan
- Build the Dockerfile.dev image to verify that the git clone and makepkg commands execute without errors
- Confirm that the yay AUR helper is installed correctly by the temporary user during the build process

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c