### PR TITLE
Simplify Dockerfile.dev git clone and yay install commands

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -119,17 +119,8 @@ RUN pacman -S --noconfirm \
 # Install additional tools from AUR (using a temporary user)
 RUN useradd -m -G wheel temp_user && \
     echo "temp_user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    su - temp_user -c "\
-        git clone https://aur.archlinux.org/yay.git /tmp/yay && \
-        cd /tmp/yay && \
-        makepkg -si --noconfirm\
-    " && \
-    su - temp_user -c "\
-        yay -S --noconfirm \
-            dive \
-            hadolint-bin \
-            shellcheck-bin\
-    " || true && \
+    su - temp_user -c "git clone https://aur.archlinux.org/yay.git /tmp/yay && cd /tmp/yay && makepkg -si --noconfirm" && \
+    su - temp_user -c "yay -S --noconfirm dive hadolint-bin shellcheck-bin" || true && \
     userdel -r temp_user && \
     sed -i '/temp_user/d' /etc/sudoers
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -124,11 +124,11 @@ RUN useradd -m -G wheel temp_user && \
         cd /tmp/yay && \
         makepkg -si --noconfirm\
     " && \
-    su - temp_user -c "
+    su - temp_user -c "\
         yay -S --noconfirm \
             dive \
             hadolint-bin \
-            shellcheck-bin
+            shellcheck-bin\
     " || true && \
     userdel -r temp_user && \
     sed -i '/temp_user/d' /etc/sudoers


### PR DESCRIPTION
## Summary
- Simplifies the `su - temp_user -c` commands in Dockerfile.dev for cloning yay and installing packages
- Combines multi-line commands into single-line commands for clarity and maintainability

## Changes

### Dockerfile.dev
- Replaced multi-line `su - temp_user -c` commands with single-line commands for git clone, makepkg, and yay package installation
- Removed unnecessary line continuations and quotes to reduce complexity

## Test plan
- [ ] Build the Docker image using Dockerfile.dev to verify no errors occur during the yay package installation step
- [ ] Confirm that the packages `dive`, `hadolint-bin`, and `shellcheck-bin` are installed successfully
- [ ] Validate that the temporary user is properly deleted after installation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c