### PR TITLE
fix: remove invalid 'target' fields from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Docker Compose configuration for Arch Linux Desktop Automation development
 # This provides a complete development environment with all necessary services
 
@@ -13,7 +11,6 @@ services:
         USER_UID: ${USER_UID:-1000}
         USER_GID: ${USER_GID:-1000}
         USERNAME: ${USERNAME:-developer}
-      target: development
     container_name: arch-desktop-dev
     hostname: arch-dev-container
 
@@ -117,7 +114,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-      target: development
     container_name: arch-desktop-docs
     hostname: docs-server
 
@@ -161,7 +157,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-      target: development
     container_name: arch-desktop-test
     hostname: test-container
 


### PR DESCRIPTION
## Summary
- Removes the `target: development` fields from the `docker-compose.yml` file
- Fixes errors related to Dockerfile multi-stage build target specification during git clone and build

## Changes

### Docker Compose Configuration
- Deleted `target: development` from all service build sections in `docker-compose.yml`:
  - `arch-desktop-dev` service
  - `arch-desktop-docs` service
  - `arch-desktop-test` service

This change ensures the Docker Compose build process does not fail due to incorrect or unsupported `target` usage in the compose file.

## Test plan
- [ ] Verify that `docker-compose up` successfully builds and runs all services without errors
- [ ] Confirm that the development, docs, and test containers start correctly
- [ ] Validate that the git clone and build steps complete without issues related to build targets

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c