### PR TITLE
Fix Dockerfile.dev package names for docker-compose and netcat

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -90,7 +90,7 @@ RUN pacman -S --noconfirm \
     nethogs \
     # Container tools
     docker \
-    docker compose \
+    docker-compose \
     # Documentation
     man-db \
     man-pages \
@@ -108,7 +108,7 @@ RUN pacman -S --noconfirm \
     fzf \
     # Network debugging
     nmap \
-    netcat \
+    gnu-netcat \
     tcpdump \
     # Process tools
     lsof \


### PR DESCRIPTION
## Summary
- Corrects package names in Dockerfile.dev to fix git clone errors related to Docker and networking tools

## Changes

### Dockerfile.dev
- Replaced `docker compose` with `docker-compose` to use the correct package name
- Replaced `netcat` with `gnu-netcat` for proper network utility installation

## Test plan
- Build the Dockerfile.dev image to ensure packages install without errors
- Verify that docker-compose commands work correctly inside the container
- Confirm network tools like netcat function as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c