### PR TITLE
Remove unused port mapping from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     ports:
       - "8080:8080" # Development server
       - "9000:9000" # Testing server
-      - "8000:8000" # Documentation server
 
     # Working directory
     working_dir: /workspace


### PR DESCRIPTION
## Summary
- Removes the unused port mapping `8000:8000` from the `docker-compose.yml` file
- Cleans up the Docker Compose configuration to avoid exposing unnecessary ports

## Changes

### Docker Configuration
- Deleted the line mapping port 8000 in the `docker-compose.yml` under the service ports section

## Test plan
- [x] Verified that the Docker Compose file no longer exposes port 8000
- [x] Confirmed that other port mappings (8080, 9000) remain unchanged and functional
- [x] Ensured no impact on container startup or service accessibility

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c