### PR TITLE
Skip UEFI check in development and container environments

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -900,10 +900,13 @@ check_system_requirements() {
         exit $EXIT_VALIDATION_ERROR
     fi
     
-    # Check UEFI boot mode
-    if [[ ! -d /sys/firmware/efi ]]; then
+    # Check UEFI boot mode (skip in development/container environments)
+    if [[ -n "${DEVELOPMENT_MODE:-}" ]] || [[ -f /.dockerenv ]]; then
+        log_info "Skipping UEFI check (development/container environment detected)"
+    elif [[ ! -d /sys/firmware/efi ]]; then
         log_error "UEFI boot mode required"
         log_error "This script requires UEFI boot mode, not legacy BIOS"
+        log_error "For development/testing, set DEVELOPMENT_MODE=true to skip this check"
         exit $EXIT_VALIDATION_ERROR
     fi
     


### PR DESCRIPTION
## Summary
- Modify UEFI boot mode check in `deploy.sh` to skip validation in development and container environments
- Add support for `DEVELOPMENT_MODE` environment variable to bypass UEFI check
- Detect Docker container environment via `/.dockerenv` file and skip UEFI check accordingly

## Changes

### Script Updates
- **deploy.sh**:
  - Updated `check_system_requirements` function to:
    - Skip UEFI boot mode check if `DEVELOPMENT_MODE` is set
    - Skip UEFI check if running inside a Docker container (detected by presence of `/.dockerenv`)
    - Log informative messages when skipping UEFI check
    - Retain original error and exit behavior if UEFI check fails outside these environments

## Test plan
- [x] Run `deploy.sh` in a normal environment without UEFI and verify it exits with error
- [x] Run `deploy.sh` with `DEVELOPMENT_MODE=true` and verify UEFI check is skipped
- [x] Run `deploy.sh` inside a Docker container and verify UEFI check is skipped
- [x] Confirm log messages appear correctly when skipping UEFI check

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7be51dae-bf88-470b-b9c9-2803da37cc2c