### PR TITLE
Change bootstrap log file path to local logs directory

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ DEFAULT_REPO_URL="https://github.com/LyeosMaouli/lm-archlinux-desktop.git"
 DEFAULT_BRANCH="main"
 WORK_DIR="/tmp/arch_automation_$$"
 CONFIG_FILE="bootstrap.conf"
-LOG_FILE="/var/log/bootstrap.log"
+LOG_FILE="./logs/bootstrap.log"
 
 # Runtime variables
 REPO_URL=""


### PR DESCRIPTION
## Summary
- Updates the log file path in `bootstrap.sh` from `/var/log/bootstrap.log` to a local `./logs/bootstrap.log` directory

## Changes

### Script Update
- Modified `LOG_FILE` variable in `bootstrap.sh` to point to `./logs/bootstrap.log` instead of the system-wide `/var/log/bootstrap.log`

## Reasoning
- Using a local logs directory can simplify permissions and make logs easier to access during development or in containerized environments.

## Test plan
- Run the bootstrap script and verify that logs are created in the `./logs` directory
- Confirm no errors occur due to log file path changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4083ff9c-1c74-4d4d-86eb-cc88b444b97f