### PR TITLE
Fix log file path error by resolving absolute path for .enc file

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -286,7 +286,7 @@ The bootstrap script needs exactly one .enc file to proceed."
     fi
     
     # Exactly one .enc file found
-    ENC_FILE_PATH="${enc_files[0]}"
+    ENC_FILE_PATH="$(realpath "${enc_files[0]}")"
     local enc_filename=$(basename "$ENC_FILE_PATH")
     
     success "Found encrypted password file: $enc_filename"


### PR DESCRIPTION
## Summary
- Fixes an issue with the log file path by ensuring the encrypted file path is resolved to an absolute path

## Changes

### Script Fix
- Updated `bootstrap.sh` to use `realpath` for the `.enc` file path
- This change ensures the script works correctly regardless of the current working directory

## Test plan
- [x] Run the bootstrap script with a single `.enc` file
- [x] Verify the script correctly identifies and logs the absolute path of the encrypted file
- [x] Confirm no path-related errors occur during execution

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0093d42f-55b3-471e-8974-fa65311cc90f