### PR TITLE
Fix log file path to use /var/log instead of project directory

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,7 +61,7 @@ if [[ "${COMMON_LOADED:-}" != "true" ]]; then
     
     # Basic logging functions as fallback
     if [[ -z "${LOG_DIR:-}" ]]; then
-        LOG_DIR="$(pwd)/logs"
+        LOG_DIR="/var/log"
     fi
     mkdir -p "$LOG_DIR"
     if [[ -z "${LOG_FILE:-}" ]]; then

--- a/scripts/internal/common.sh
+++ b/scripts/internal/common.sh
@@ -10,7 +10,7 @@
 # Global configuration
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-readonly LOG_DIR="$PROJECT_ROOT/logs"
+readonly LOG_DIR="/var/log"
 readonly CONFIG_DIR="$PROJECT_ROOT/config"
 readonly CACHE_DIR="$PROJECT_ROOT/.cache"
 


### PR DESCRIPTION
## Summary
- Corrects the log directory path from the project directory to the system standard `/var/log`
- Ensures logs are stored in a consistent and appropriate location

## Changes

### Script Updates
- **scripts/deploy.sh**: Changed default `LOG_DIR` from `$(pwd)/logs` to `/var/log` when `LOG_DIR` is not set
- **scripts/internal/common.sh**: Updated `LOG_DIR` constant from `$PROJECT_ROOT/logs` to `/var/log`

## Test plan
- [x] Verify that logs are created in `/var/log` instead of the project directory
- [x] Confirm no errors occur related to log file paths during deployment
- [x] Check that log directory creation works as expected with the new path

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0093d42f-55b3-471e-8974-fa65311cc90f