### PR TITLE
Fix VM disk errors by reducing EFI size and adding disk space checks

### DIFF
--- a/scripts/deployment/auto_install.sh
+++ b/scripts/deployment/auto_install.sh
@@ -313,7 +313,7 @@ setup_partitions() {
     local efi_size=$(parse_nested_config "disk" "efi_size")
     
     if [[ -z "${efi_size:-}" ]]; then
-        efi_size="512M"
+        efi_size="256M"  # Conservative EFI size to maximize root partition space
     fi
     
     info "Setting up partitions on $disk_device..."
@@ -806,10 +806,29 @@ install_base_system() {
     # Add XferCommand in the [options] section
     sed -i '/^ParallelDownloads/a XferCommand = /usr/bin/curl -L -C - -f --retry 5 --retry-delay 3 --connect-timeout 60 -o %o %u' /etc/pacman.conf
     
+    # Clean package cache to free up space
+    info "Cleaning package cache to free up space..."
+    pacman -Scc --noconfirm || warn "Failed to clean package cache"
+    
+    # Check available disk space before installation
+    info "Checking available disk space..."
+    local available_space_kb=$(df /mnt | tail -1 | awk '{print $4}')
+    local available_space_gb=$((available_space_kb / 1024 / 1024))
+    info "Available space in /mnt: ${available_space_gb}GB"
+    
+    if [[ $available_space_gb -lt 5 ]]; then
+        error "Insufficient disk space for installation (${available_space_gb}GB < 5GB required)"
+        error "Available space breakdown:"
+        df -h /mnt
+        lsblk
+        return 1
+    fi
+    
     # Try pacstrap with better error handling and diagnostics
     info "Starting package installation with pacstrap..."
     echo "=== PACSTRAP INSTALLATION ATTEMPT ===" >> "$VERBOSE_LOG"
     echo "Target: /mnt" >> "$VERBOSE_LOG"
+    echo "Available space: ${available_space_gb}GB" >> "$VERBOSE_LOG"
     echo "Packages: base base-devel linux linux-firmware networkmanager sudo git openssh neovim intel-ucode" >> "$VERBOSE_LOG"
     echo "Mirror list being used:" >> "$VERBOSE_LOG"
     cat /etc/pacman.d/mirrorlist >> "$VERBOSE_LOG" 2>&1

--- a/scripts/testing/auto_vm_test.sh
+++ b/scripts/testing/auto_vm_test.sh
@@ -143,8 +143,8 @@ disk:
     enabled: true
     passphrase: "test123"  # Simple passphrase for testing
   partitions:
-    efi_size: "512M"
-    swap_size: "2G"  # Smaller for VM
+    efi_size: "256M"  # Reduced EFI size to save space
+    # Note: No swap partition - using zram instead
   filesystem: "ext4"
 
 # Bootloader Configuration


### PR DESCRIPTION
## Summary
- Reduces EFI partition size from 512M to 256M to maximize root partition space
- Adds disk space availability check before base system installation to prevent errors
- Cleans package cache during installation to free up disk space
- Updates VM test configuration to reflect reduced EFI size and no swap partition (using zram instead)

## Changes

### Deployment Script (`auto_install.sh`)
- Changed default EFI partition size to 256M for more efficient disk usage
- Added package cache cleaning step to free up space before installation
- Implemented disk space check on `/mnt` to ensure at least 5GB is available before proceeding
- Enhanced logging with available disk space details for better diagnostics

### Testing Script (`auto_vm_test.sh`)
- Updated VM test disk configuration to use 256M EFI partition
- Removed swap partition in favor of zram for VM testing environment

## Test plan
- [x] Verified that installation proceeds without disk space errors on 60GB VM disk
- [x] Confirmed EFI partition size is set to 256M during installation
- [x] Ran VM tests with updated disk configuration successfully
- [x] Checked logs for disk space availability messages and cache cleaning confirmation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5d016617-d25a-4dbc-a6f8-9cdb636344bb