### PR TITLE
Fix password utils error by robustly sourcing common.sh in scripts

### DIFF
--- a/scripts/deployment/auto_install.sh
+++ b/scripts/deployment/auto_install.sh
@@ -8,10 +8,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is deployment/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration file path
 CONFIG_FILE="${CONFIG_FILE:-/tmp/deployment_config.yml}"

--- a/scripts/deployment/auto_network_setup.sh
+++ b/scripts/deployment/auto_network_setup.sh
@@ -8,10 +8,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is deployment/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Check if we're connected to internet
 check_internet() {

--- a/scripts/deployment/auto_post_install.sh
+++ b/scripts/deployment/auto_post_install.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is deployment/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration
 CONFIG_FILE="${CONFIG_FILE:-$HOME/lm-archlinux-desktop/deployment_config.yml}"

--- a/scripts/deployment/profile_manager.sh
+++ b/scripts/deployment/profile_manager.sh
@@ -8,10 +8,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is deployment/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration
 if [[ -z "${PROJECT_ROOT:-}" ]]; then

--- a/scripts/deployment/secure_prompt_handler.sh
+++ b/scripts/deployment/secure_prompt_handler.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is deployment/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Global variables for storing secure data
 USER_PASSWORD=""

--- a/scripts/maintenance/health_check.sh
+++ b/scripts/maintenance/health_check.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is maintenance/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration
 REPORT_FILE="/tmp/health_check_report.txt"

--- a/scripts/security/fail2ban_setup.sh
+++ b/scripts/security/fail2ban_setup.sh
@@ -7,10 +7,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is security/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Check if running as root
 if [[ $EUID -ne 0 ]]; then

--- a/scripts/security/firewall_setup.sh
+++ b/scripts/security/firewall_setup.sh
@@ -8,10 +8,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is security/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Check if running as root
 if [[ $EUID -ne 0 ]]; then

--- a/scripts/security/security_audit.sh
+++ b/scripts/security/security_audit.sh
@@ -7,10 +7,26 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is security/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Create audit-specific report file
 REPORT_FILE="$LOG_DIR/security-audit-$(date +%Y%m%d-%H%M%S).log"

--- a/scripts/security/system_hardening.sh
+++ b/scripts/security/system_hardening.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is security/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Check if running as root
 if [[ $EUID -ne 0 ]]; then

--- a/scripts/utilities/create_password_file.sh
+++ b/scripts/utilities/create_password_file.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utilities/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Script configuration
 SECURITY_DIR="$SCRIPT_DIR/../security"

--- a/scripts/utilities/network_auto_setup.sh
+++ b/scripts/utilities/network_auto_setup.sh
@@ -5,11 +5,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utilities/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration
 CONFIG_FILE="${CONFIG_FILE:-$HOME/deployment_config.yml}"

--- a/scripts/utils/deployment_monitor.sh
+++ b/scripts/utils/deployment_monitor.sh
@@ -9,11 +9,30 @@
 set -euo pipefail
 
 # Load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../internal/common.sh" || {
-    echo "Error: Cannot load common.sh"
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
     exit 1
-}
+fi
 
 # Configuration
 MONITOR_LOG_FILE="$LOG_DIR/deployment-monitor.log"

--- a/scripts/utils/hardware.sh
+++ b/scripts/utils/hardware.sh
@@ -27,8 +27,27 @@
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-# shellcheck source=../internal/common.sh
-source "$SCRIPT_DIR/../internal/common.sh"
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
+    exit 1
+fi
 
 # Hardware detection results (global state)
 declare -A HARDWARE_INFO

--- a/scripts/utils/network.sh
+++ b/scripts/utils/network.sh
@@ -24,8 +24,27 @@
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-# shellcheck source=../internal/common.sh
-source "$SCRIPT_DIR/../internal/common.sh"
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
+    exit 1
+fi
 
 # Network configuration
 readonly NETWORK_TEST_HOSTS=("8.8.8.8" "1.1.1.1" "208.67.222.222")

--- a/scripts/utils/passwords.sh
+++ b/scripts/utils/passwords.sh
@@ -24,8 +24,27 @@ set -euo pipefail
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-# shellcheck source=../internal/common.sh  
-source "$SCRIPT_DIR/../internal/common.sh"
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
+    exit 1
+fi
 
 # Password management configuration
 readonly PASSWORD_MIN_LENGTH=8

--- a/scripts/utils/profiles.sh
+++ b/scripts/utils/profiles.sh
@@ -26,8 +26,27 @@
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-# shellcheck source=../internal/common.sh
-source "$SCRIPT_DIR/../internal/common.sh"
+
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
+    exit 1
+fi
 
 # Profile configuration
 readonly PROFILES_DIR="$PROJECT_ROOT/configs/profiles"

--- a/scripts/utils/validation.sh
+++ b/scripts/utils/validation.sh
@@ -29,14 +29,34 @@
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-# shellcheck source=../internal/common.sh
-source "$SCRIPT_DIR/../internal/common.sh"
 
-# Load other utilities
+# Try multiple paths for common.sh to handle different execution contexts
+COMMON_PATHS=(
+    "$SCRIPT_DIR/../internal/common.sh"        # When SCRIPT_DIR is utils/
+    "$SCRIPT_DIR/internal/common.sh"           # When SCRIPT_DIR is scripts/
+    "$SCRIPT_DIR/../scripts/internal/common.sh" # When in project root
+)
+
+COMMON_LOADED=false
+for COMMON_PATH in "${COMMON_PATHS[@]}"; do
+    if [[ -f "$COMMON_PATH" ]]; then
+        # shellcheck source=../internal/common.sh
+        source "$COMMON_PATH" && COMMON_LOADED=true && break
+    fi
+done
+
+if [[ "${COMMON_LOADED:-}" != "true" ]]; then
+    echo "Error: Cannot load common.sh from any expected location" >&2
+    echo "Tried paths: ${COMMON_PATHS[*]}" >&2
+    exit 1
+fi
+
+# Load other utilities from the same directory as this script
+UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=hardware.sh
-source "$SCRIPT_DIR/hardware.sh"
+source "$UTILS_DIR/hardware.sh"
 # shellcheck source=network.sh
-source "$SCRIPT_DIR/network.sh"
+source "$UTILS_DIR/network.sh"
 
 # Validation results tracking
 declare -A VALIDATION_RESULTS


### PR DESCRIPTION
## Summary
- Resolves errors in password utilities and other scripts caused by failing to source `common.sh`.
- Implements a robust mechanism to locate and source `common.sh` from multiple possible paths across all affected scripts.
- Ensures consistent loading of shared functions regardless of script execution context or directory.

## Changes

### Script Loading Improvements
- Replaced single-path sourcing of `common.sh` with a loop that tries multiple expected locations:
  - `../internal/common.sh` (typical for deployment, security, utilities, maintenance, and utils scripts)
  - `internal/common.sh` (when running from scripts directory)
  - `../scripts/internal/common.sh` (when running from project root)
- Added error messages listing all attempted paths if `common.sh` cannot be found, improving debugging.
- Applied this pattern uniformly to 18 scripts including deployment, security, utilities, maintenance, and utils scripts.

### Specific Scripts Updated
- Deployment scripts: `auto_install.sh`, `auto_network_setup.sh`, `auto_post_install.sh`, `profile_manager.sh`, `secure_prompt_handler.sh`
- Maintenance script: `health_check.sh`
- Security scripts: `fail2ban_setup.sh`, `firewall_setup.sh`, `security_audit.sh`, `system_hardening.sh`
- Utilities scripts: `create_password_file.sh`, `network_auto_setup.sh`
- Utils scripts: `deployment_monitor.sh`, `hardware.sh`, `network.sh`, `passwords.sh`, `profiles.sh`, `validation.sh`

### Additional Fixes
- In `validation.sh`, updated sourcing of other utility scripts (`hardware.sh` and `network.sh`) to use a local directory variable for consistency.

## Test plan
- [x] Verified all scripts load `common.sh` successfully from various execution contexts.
- [x] Confirmed no errors occur related to missing `common.sh` when running password utilities.
- [x] Ran deployment, security, maintenance, and utility scripts to ensure functionality remains intact.
- [x] Checked error messages appear correctly if `common.sh` is missing.

This change improves the reliability and portability of the scripts by ensuring shared functions are always accessible, fixing the password utilities error and preventing similar issues in other scripts.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fd6f71da-440c-436a-bbdb-8b2670079bbe